### PR TITLE
wyng-extract: non-working cleanup

### DIFF
--- a/misc/wyng-extract.sh
+++ b/misc/wyng-extract.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/ash
 
 # wyng-extract.sh  -  Simple disk image extractor for Wyng archives.
 #  Copyright Christopher Laprise 2018-2021 / tasket@protonmail.com
@@ -26,7 +26,7 @@ done
 shift $(( OPTIND - 1 ))
 
 if [ -n "$outopt" ]; then
-  outvol=`realpath "$outopt"`
+  outvol=$outopt
 elif [ -z "$opt_check" ] && [ -z "$opt_list" ]; then
   opterr=1
 fi
@@ -60,193 +60,199 @@ if [ -e $tmpdir ]; then mv $tmpdir $tmpdir.old; fi
 rm -rf $tmpdir $tmpdir.old  &&  mkdir $tmpdir
 
 
-( cd "$voldir";  curdir=`pwd`
+cd "$voldir";  curdir=$(pwd)
 
-  # Check that format version is 1 or 2
-  arch_ver=`grep '^format_ver =' volinfo | awk '{print $3}'`
-  case $arch_ver in
-    1|2)  format_ver=$arch_ver;;
-    *)    echo "Error: Did not find a compatible format.";  exit 1;;
-  esac
+# Check that format version is 1 or 2
+arch_ver=$(grep '^format_ver =' volinfo | awk '{print $3}')
+case $arch_ver in
+  1|2)  format_ver=$arch_ver;;
+  *)    echo "Error: Did not find a compatible format.";  exit 1;;
+esac
 
-  echo "Getting metadata for volume $volname."
-  ln=`grep -E '^last =' volinfo`;   read one two s_last <<<"$ln"
-  cp volinfo $tmpdir;  sed -E '/\[volumes/q' ../archive.ini >$tmpdir/archive.ini
+echo "Getting metadata for volume $volname."
+ln=$(grep -E '^last =' volinfo);   s_last=$(echo "$ln" | cut -d " " -f3-)
+cp volinfo $tmpdir;  sed -E '/\[volumes/q' ../archive.ini >$tmpdir/archive.ini
 
-  # Add session column to manifests and create symlinks using sequence number.
-  if [ -z "$sestag" ]; then sestag=${s_last:2}; fi
-  session=$s_last
-  while [ ! ${session,,} = 'none' ]; do
-    ln=`grep '^previous =' $session/info`;  read one two s_prev <<<"$ln"
-    if [ -z "$sesnames" ] && [ ! "${session:2}" = "$sestag" ]; then session=$s_prev;  continue; fi
+# Add session column to manifests and create symlinks using sequence number.
+if [ -z "$sestag" ]; then sestag=$(echo "$s_last" | cut -d " " -f2); fi
+session=$s_last
+while [ ! "$session" = 'none' ] && [ ! "$session" = 'None' ]; do
+  ln=$(grep '^previous =' "$session"/info);  s_prev=$(echo "$ln" | cut -d " " -f3-)
+  if [ -z "$sesnames" ] && [ ! "$(echo "$session" | cut -d " " -f2)" = "$sestag" ]; then session=$s_prev;  continue; fi
 
-    ln=`grep '^sequence =' $session/info`;  read one two sequence <<<"$ln"
-    sed 's|$| S_'$sequence'|'  $session/manifest  >$tmpdir/m_$sequence
-    ln -s "$curdir/$session" $tmpdir/S_$sequence
+  ln=$(grep '^sequence =' "$session"/info);  sequence=$(echo "$ln" | cut -d " " -f3-)
+  sed 's|$| S_'"$sequence"'|'  "$session"/manifest  >$tmpdir/m_"$sequence"
+  ln -s "$curdir/$session" $tmpdir/S_"$sequence"
 
-    sesnames="$session $sesnames";  session=$s_prev
+  sesnames="$session $sesnames";  session=$s_prev
+done
+
+# List sessions and exit.
+if [ -n "$opt_list" ]; then
+  for ses in $sesnames; do
+    echo "$ses"| cut -d " " -f2  
+    sed -n 's|^tag |  tag |;T;p' "$ses"/info
   done
+  exit 0
+fi
 
-  # List sessions and exit.
-  if [ -n "$opt_list" ]; then
-    for ses in $sesnames; do
-      echo ${ses:2};  sed -n 's|^tag |  tag |;T;p' $ses/info
-    done
-    exit 0
-  fi
-
-  if [ -z "$sesnames" ]; then echo "Error: Session not found."; exit 1; fi
-  echo -n "$sesnames"  >$tmpdir/sesnames
-)
+if [ -z "$sesnames" ]; then echo "Error: Session not found."; exit 1; fi
+echo -n "$sesnames"  >$tmpdir/sesnames
 
 
 if [ -n "$opt_list" ]; then exit 0; fi
 
 
-( cd $tmpdir
+cd $tmpdir
 
-  # Get a list of manifest files, sorted by sequence in filename, as 'm_last' and 'm_therest'.
-  ln=`find . -name 'm_*' -exec basename '{}' \; | sort --reverse -V | tr '\n' ' '`
-  read m_last m_therest <<<"$ln"
-  read sesnames  <<< `cat sesnames`
+# Get a list of manifest files, sorted by sequence in filename, as 'm_last' and 'm_therest'.
+ln=$(find . -name 'm_*' -exec basename '{}' \; | sort -r -V | tr '\n' ' ')
+m_last=$(echo "$ln" | cut -d " " -f1)
+sesnames=$(cat sesnames)
 
-  # Get volume size, chunk size, compression, hash type and last chunk address.
-  ln=`grep -E '^volsize =' S_${m_last#m_}/info`;  read one two volsize <<<"$ln"
-  ln=`grep -E '^vgname ='  archive.ini`;          read one two vgname <<<"$ln"
-  ln=`grep -E '^chunksize ='  archive.ini`;       read one two chunksize <<<"$ln"
-  ln=`grep -E '^compression ='  archive.ini`;     read one two compr <<<"$ln"
-  ln=`grep -E '^compr_level ='  archive.ini`;     read one two compr_level <<<"$ln"
-  ln=`grep -E '^hashtype ='  archive.ini`;        read one two hashtype <<<"$ln"
-  lastchunk=`printf '%016x' $(( ($volsize - 1) - (($volsize - 1) % $chunksize) ))`
-  echo "Volume size = $volsize bytes."
+# Get volume size, chunk size, compression, hash type and last chunk address.
+ln=$(grep -E '^volsize =' S_"${m_last#m_}"/info);  volsize=$(echo "$ln" | cut -d " " -f3-)
+ln=$(grep -E '^vgname ='  archive.ini);            vgname=$(echo "$ln" | cut -d " " -f3-)
+ln=$(grep -E '^chunksize ='  archive.ini);         chunksize=$(echo "$ln" | cut -d " " -f3-)
+ln=$(grep -E '^compression ='  archive.ini);       compr=$(echo "$ln" | cut -d " " -f3-)
+ln=$(grep -E '^compr_level ='  archive.ini);       compr_level=$(echo "$ln" | cut -d " " -f3-)
+ln=$(grep -E '^hashtype ='  archive.ini);          hashtype=$(echo "$ln" | cut -d " " -f3-)
+lastchunk=$(printf '%016x' $(( ($volsize - 1) - (($volsize - 1) % $chunksize) )))
+echo "Volume size = $volsize bytes."
 
-  case $compr in
-    zstd)  DECOMPRESS="zstdcat";    COMPRESS="zstd -T2 -$compr_level";;
-    zlib)  DECOMPRESS="unpigz -cz"; COMPRESS="pigz -z -$compr_level";;
-    bz2)   DECOMPRESS="bzcat";      COMPRESS="bzip2 -$compr_level";;
-  esac
+case $compr in
+  zstd)  DECOMPRESS="zstdcat";    COMPRESS="zstd -T2 -$compr_level";;
+  zlib)  DECOMPRESS="unpigz -cz"; COMPRESS="pigz -z -$compr_level";;
+  bz2)   DECOMPRESS="bzcat";      COMPRESS="bzip2 -$compr_level";;
+esac
 
-  case $hashtype in
-    sha256)   HASH_CHECK="sha256sum";;
-    blake2b)  HASH_CHECK="b2sum -l $(( hashw * 4 ))";;
-  esac
+case $hashtype in
+  sha256)   HASH_CHECK="sha256sum";;
+  blake2b)  HASH_CHECK="b2sum -l $(( hashw * 4 ))";;
+esac
 
-  # Parse manifest fields: 1=digest, 2=first fname segment, 3=second fname seg, 4=session
-  mregex='^(\S+)\s+x(\S{9})(\S+)\s+(S_\S+)'
+# Parse manifest fields: 1=digest, 2=first fname segment, 3=second fname seg, 4=session
+mregex='^(\S+)\s+x(\S{9})(\S+)\s+(S_\S+)'
 
-  # Hash local volume for sparse mode:
-  # Creates a complete 'manifest' from a local volume
-  # which is then compared vs Wyng archive manifests.
-  chunks=1024 # batch size
-  megachunksize=$(( chunksize * chunks ))
-  truncate --size $chunksize ZERO
-  $COMPRESS -c ZERO >ZERO.c
-  ln=`$HASH_CHECK ZERO.c`;  read zhash two <<<"$ln"
-  mkdir CHK
+# Hash local volume for sparse mode:
+# Creates a complete 'manifest' from a local volume
+# which is then compared vs Wyng archive manifests.
+chunks=1024 # batch size
+megachunksize=$(( $chunksize * $chunks ))
+echo "megachunksize:" $megachunksize 
+truncate -s "$chunksize" ZERO
+$COMPRESS -c ZERO >ZERO.c
+ln=$($HASH_CHECK ZERO.c);  zhash=$(echo "$ln"| cut -d " " -f1)
+mkdir CHK
 
-  if [ -n "$opt_sparse" ]; then
-    if [ "$compr" = "zlib" ]; then
-      echo "Error: Sparse mode not yet supported with zlib compression."
-      exit 1
-    fi
-
-    # Make local vol correct size for comparison
-    if [ ! -b "$outvol" ]; then
-      truncate --size $volsize "$outvol"
-    elif lvm lvdisplay "$outvol" >/dev/null; then
-      lvm lvresize -L ${volsize}B "$outvol" 2>/dev/null
-    fi
-
-    for ((i=0; i<volsize; i=i+megachunksize)); do
-      echo -en "Hashing volume $i \r"
-      dd if="$outvol" bs=$chunksize count=$chunks skip=$i iflag=skip_bytes status=none \
-      |  split -d -a 5 -b $chunksize - CHK/
-
-      cd CHK
-
-      # Compress chunk files
-      find . -name '*[0-9][0-4]'  |  xargs -r $COMPRESS  ||  touch ../cmprfail  &
-      find . -name '*[0-9][5-9]'  |  xargs -r $COMPRESS  ||  touch ../cmprfail  &
-      wait
-      if [ -e ../cmprfail ]; then
-        echo "Compression error."; exit 1
-      fi
-
-      # Hash the chunk files, remove extension, convert 2nd col to hex fname
-      find . -type f -printf '%f\n' \
-      |  xargs -r $HASH_CHECK  |  sed -E 's|\..+$||'  |  sort -k2,2  \
-      |  awk -v i="$i" -v cs="$chunksize" '{ printf "%s x%.16x\n", $1, $2 * cs + i }' \
-      >>../local-manifest
-
-      cd ..;   rm -f CHK/*
-    done
-
-    echo -en "\nCreating diff index..."
-    sort -um -k2,2 $m_last $m_therest  |  sed -E '/ x'$lastchunk'/q; s|^0\s+|'$zhash' |' \
-    |  sort -ms -k2,2 - local-manifest  |  uniq -u -w $uniqw  |  sort -um -k2,2  \
-    |  sed -E 's|^'$zhash'|0|'  \
-    >diff-manifest
-
-    if [ -n "$opt_diff" ]; then
-      echo '---'
-      cat diff-manifest
-      exit $(( `wc -l diff-manifest | cut -d ' ' -f1` > 0 ))
-    fi
-
-    # Create a zerofill manifest for the extraction merge-sort.
-    # This will fill-in any address gaps in the diff as zero chunks.
-    sed -E 's|^\S+|0|' local-manifest  >zerofill-manifest
-
-    # Zeros from diff-manifest must be 'punched' into local volume since
-    # final step uses zeros for sparse seeking. Needs optimizing.
-    echo -en "\nFilling zeros..."
-    sed -E 's|^0\s+(\S+)\s*.*|0\1|; t; d' diff-manifest  \
-    |  xargs -i -r $HOLEPUNCH -z -l $chunksize -o {} "$outvol"
-
-    echo -en "\nChecking volume hashes..."
-    sed -E '/^0 x/ d; s|'"$mregex"'|\1 \4/\2/x\2\3|;' diff-manifest  \
-    |  $HASH_CHECK -c --status
-
-    # Change the merge-sort inputs to use the differential versions during extraction.
-    m_last=diff-manifest
-    m_therest=zerofill-manifest
-
-  elif [ "$opt_check" = 1 ]; then
-    # Test entire arch volume integrity against manifest hashes.
-    echo -n "Checking volume hashes..."
-
-    sort -umd -k2,2 $m_last $m_therest  |  sed -E "/ x$lastchunk/q" \
-    |  sed -E '/^0 x/ d; s|'"$mregex"'|\1 \4/\2/x\2\3|;' \
-    |  $HASH_CHECK -c --status
-
-    exit 0
-  fi
-
-
-  echo -en "\nExtracting data to $outvol..."
-
-  # Set local volume to correct size.
-  if [ ! -b "$outvol" ]; then
-    if [ -z "$opt_sparse" ]; then rm -f "$outvol"; fi
-    truncate --size $volsize "$outvol"
-  elif lvm lvdisplay "$outvol" >/dev/null; then
-    if [ -z "$opt_sparse" ]; then blkdiscard "$outvol"; fi
-    lvm lvresize -L ${volsize}B "$outvol" 2>/dev/null || true
-  fi
-  if [ ! -e "$outvol" ]; then
-    echo "Error: Output/save path does not exist!"
+if [ -n "$opt_sparse" ]; then
+  if [ "$compr" = "zlib" ]; then
+    echo "Error: Sparse mode not yet supported with zlib compression."
     exit 1
   fi
 
-  # Merge-sort complete manifest & convert to simple filenames for decompressor,
-  # then pipe data to dd.
-  sort -um -k2,2 $m_last $m_therest  |  sed -E "/ x$lastchunk/q" \
-  |  sed -E 's|^0 x.*|ZERO|; t; s|'"$mregex"'|\4/\2/x\2\3|'  \
-  |  xargs $DECOMPRESS -f  \
-  |  dd of="$outvol"  obs=$chunksize conv=sparse,notrunc,nocreat
+  # Make local vol correct size for comparison
+  if [ ! -b "$outvol" ]; then
+    truncate --size "$volsize" "$outvol"
+    echo "truncating to $volsize $outvol"
+  elif lvm lvdisplay "$outvol" >/dev/null; then
+    lvm lvresize -L "${volsize}"B "$outvol" 2>/dev/null
+    echo "resizing to $volside $outvol"
+  fi
+  
+  i=0
+  while [ "$i" -lt "$volsize" ]; do
+  #for ((i=0; i<volsize; i=i+megachunksize)); do
+    i+="$megachunksize";
+    echo -en "Hashing volume $i \r"
+    dd if="$outvol" bs="$chunksize" count=$chunks skip=$i iflag=skip_bytes status=none \
+    |  split -d -a 5 -b "$chunksize" - CHK/
 
-  sync
-)
+    cd CHK
+
+    # Compress chunk files
+    find . -name '*[0-9][0-4]'  |  xargs -r "$COMPRESS"  ||  touch ../cmprfail  &
+    find . -name '*[0-9][5-9]'  |  xargs -r "$COMPRESS"  ||  touch ../cmprfail  &
+    wait
+    if [ -e ../cmprfail ]; then
+      echo "Compression error."; exit 1
+    fi
+
+    # Hash the chunk files, remove extension, convert 2nd col to hex fname
+    find . -type f -printf '%f\n' \
+    |  xargs -r "$HASH_CHECK"  |  sed -E 's|\..+$||'  |  sort -k2,2  \
+    |  awk -v i="$i" -v cs="$chunksize" '{ printf "%s x%.16x\n", $1, $2 * cs + i }' \
+    >>../local-manifest
+
+    cd ..;   rm -f CHK/*
+  done
+
+  echo -en "\nCreating diff index..."
+  sort -um -k2,2 "$m_last" "$m_therest"  |  sed -E '/ x'"$lastchunk"'/q; s|^0\s+|'"$zhash"' |' \
+  |  sort -ms -k2,2 - local-manifest  |  uniq -u -w $uniqw  |  sort -um -k2,2  \
+  |  sed -E 's|^'"$zhash"'|0|'  \
+  >diff-manifest
+
+  if [ -n "$opt_diff" ]; then
+    echo '---'
+    cat diff-manifest
+    exit $(( $(wc -l diff-manifest | cut -d ' ' -f1) > 0 ))
+  fi
+
+  # Create a zerofill manifest for the extraction merge-sort.
+  # This will fill-in any address gaps in the diff as zero chunks.
+  sed -E 's|^\S+|0|' local-manifest  >zerofill-manifest
+
+  # Zeros from diff-manifest must be 'punched' into local volume since
+  # final step uses zeros for sparse seeking. Needs optimizing.
+  echo -en "\nFilling zeros..."
+  sed -E 's|^0\s+(\S+)\s*.*|0\1|; t; d' diff-manifest  \
+  |  xargs -i -r $HOLEPUNCH -z -l "$chunksize" -o {} "$outvol"
+
+  echo -en "\nChecking volume hashes..."
+  sed -E '/^0 x/ d; s|'"$mregex"'|\1 \4/\2/x\2\3|;' diff-manifest  \
+  |  $HASH_CHECK -c --status
+
+  # Change the merge-sort inputs to use the differential versions during extraction.
+  m_last=diff-manifest
+  m_therest=zerofill-manifest
+
+elif [ "$opt_check" = 1 ]; then
+  # Test entire arch volume integrity against manifest hashes.
+  echo -n "Checking volume hashes..."
+
+  sort -umd -k2,2 $m_last $m_therest  |  sed -E "/ x$lastchunk/q" \
+  |  sed -E '/^0 x/ d; s|'"$mregex"'|\1 \4/\2/x\2\3|;' \
+  |  $HASH_CHECK -c --status
+
+  exit 0
+fi
+
+
+echo -en "\nExtracting data to $outvol..."
+
+# Set local volume to correct size.
+if [ ! -b "$outvol" ]; then
+  if [ -z "$opt_sparse" ]; then rm -f "$outvol"; fi
+  truncate --size "$volsize" "$outvol"
+elif lvm lvdisplay "$outvol" >/dev/null; then
+  if [ -z "$opt_sparse" ]; then blkdiscard "$outvol"; fi
+  lvm lvresize -L "${volsize}"B "$outvol" 2>/dev/null || true
+fi
+if [ ! -e "$outvol" ]; then
+  echo "Error: Output/save path does not exist!"
+  exit 1
+fi
+
+# Merge-sort complete manifest & convert to simple filenames for decompressor,
+# then pipe data to dd.
+sort -um -k2,2 $m_last $m_therest  |  sed -E "/ x$lastchunk/q" \
+|  sed -E 's|^0 x.*|ZERO|; t; s|'"$mregex"'|\4/\2/x\2\3|'  \
+|  xargs $DECOMPRESS -f  \
+|  dd of="$outvol"  obs="$chunksize" conv=sparse,notrunc,nocreat
+
+sync
+
 
 echo
 echo "OK"


### PR DESCRIPTION
Hey @tasket 

Here is my current attempt to fix incompatibilities between bash/ash, where busybox is more on the dash side even when bash compatibility is on.

I would love you to be able to pick up on that work, and take whatever you like and merge it to upstream.

I made it not work at all, but 
- cleaned things like <<< which are not supported, replaced with cut calls
- realpath is not supported
- broke `( )` functions and indent, but ash was complaining, not sure how to fix that but rewrite those parts
- case changing `${var,,}` not supported
- etc

In current state, console stops output showing megachunk added echo and dies without going further.....
Any help appreciated.


I will point WiP heads PR that I finally gave some love to. It now includes functional blake2 and zstd, thin provisioning support without complaining of thin-provisioning tools missing and newer busybox version (making ash more compatible to bash but quite not there yet, so bashisms should be replaced everywhere).